### PR TITLE
Populate members information

### DIFF
--- a/backend/src/models/member.ts
+++ b/backend/src/models/member.ts
@@ -15,7 +15,7 @@ const MemberSchema = new Schema<MemberModel>({
   country: { type: String, required: true },
   memberPosition: { type: String, required: true },
   linkedinUrl: { type: String, required: true },
-  headshotUrl: { type: String, required: true },
+  headshotUrl: { type: String, required: false },
 });
 
 export default model<MemberModel>("Member", MemberSchema);

--- a/frontend/src/components/MemberCard.tsx
+++ b/frontend/src/components/MemberCard.tsx
@@ -32,10 +32,16 @@ export const MemberCard: React.FC<MemberCardProps> = ({ member }) => {
       <div className="flex flex-col flex-start gap-[30px]">
         <div className="relative" style={{ width: 250, height: 250 }}>
           <Image
-            src={member.headshotUrl}
+            src={
+              !member.headshotUrl || member.headshotUrl === ""
+                ? "https://firebasestorage.googleapis.com/v0/b/f3-global.firebasestorage.app/o/members-pictures%2Fdefault%20profile%20picture.jpg?alt=media&token=c3eb3836-5edf-42c5-bf4a-5a47ee5ba1df"
+                : member.headshotUrl
+            }
             alt={`${member.name} headshot image`}
             fill
+            sizes="250px"
             className="object-cover object-center bg-cover bg-no-repeat bg-center rounded-[250px] "
+            unoptimized
           />
         </div>
         <div className="flex flex-col items-start gap-[10px] self-stretch">


### PR DESCRIPTION
## Tracking Info

Resolves #80

## Changes

- made headshotUrl optional in member model
- changed Member Card to use default image if headshot URL is not available
- updated database to have all member info

## Testing

- Postman for data checks
- Manual testing for frontent

## Confirmation of Change

https://github.com/user-attachments/assets/c7d31dc1-0d5b-4ee4-b202-0eed68ce1fb9

Note: changed image loading to `unoptimized` to allow for all images stored in Firebase to load in correctly. Changing to `optimized` does not seem to have significant performance gains, but if this is a hard requirement, then images that come in for headshots will need to be standardized, as some of the images did not load under `optimized` mode for me. Would love to know what other people see to know if this is an issue with my computer or in general.
