### PR TITLE
Meet the Team: US-first ordering, role-based member sorting, LinkedIn icon-only

### DIFF
--- a/frontend/src/app/(public)/meet-the-team/page.tsx
+++ b/frontend/src/app/(public)/meet-the-team/page.tsx
@@ -13,6 +13,28 @@ import { InteractiveWorldMap } from "@/components/InteractiveWorldMap";
 
 countriesInfo.registerLocale(enLocale);
 
+const CSUITE_KEYWORDS = [
+  "ceo",
+  "coo",
+  "cfo",
+  "cto",
+  "cmo",
+  "cio",
+  "cso",
+  "cpo",
+  "co-head",
+  "cohead",
+  "co-founder",
+];
+const DIRECTOR_KEYWORDS = ["director"];
+
+function getMemberTier(position: string): number {
+  const lower = position.toLowerCase();
+  if (CSUITE_KEYWORDS.some((k) => lower.includes(k))) return 0;
+  if (DIRECTOR_KEYWORDS.some((k) => lower.includes(k))) return 1;
+  return 2;
+}
+
 export type Member = {
   _id: string;
   name: string;
@@ -95,7 +117,21 @@ export default function MeetTheTeam() {
     });
   }, [membersByCountry]);
 
-  const countries = Object.keys(membersByCountry).sort((a, b) => a.localeCompare(b));
+  const sortedMembersByCountry = useMemo(() => {
+    const sorted: Record<string, Member[]> = {};
+    for (const country of Object.keys(membersByCountry)) {
+      sorted[country] = [...membersByCountry[country]].sort(
+        (a, b) => getMemberTier(a.memberPosition) - getMemberTier(b.memberPosition),
+      );
+    }
+    return sorted;
+  }, [membersByCountry]);
+
+  const countries = Object.keys(membersByCountry).sort((a, b) => {
+    if (a === "United States") return -1;
+    if (b === "United States") return 1;
+    return a.localeCompare(b);
+  });
 
   const [colleges, setColleges] = useState<College[]>([]);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -222,7 +258,7 @@ export default function MeetTheTeam() {
                 key={countryName}
                 id={`members-${code}`}
                 countryName={countryName}
-                members={membersByCountry[countryName]}
+                members={sortedMembersByCountry[countryName]}
               />
             );
           })}

--- a/frontend/src/app/(public)/meet-the-team/page.tsx
+++ b/frontend/src/app/(public)/meet-the-team/page.tsx
@@ -30,8 +30,8 @@ const DIRECTOR_KEYWORDS = ["director"];
 
 function getMemberTier(position: string): number {
   const lower = position.toLowerCase();
-  if (CSUITE_KEYWORDS.some((k) => lower.includes(k))) return 0;
-  if (DIRECTOR_KEYWORDS.some((k) => lower.includes(k))) return 1;
+  if (CSUITE_KEYWORDS.some((k) => new RegExp(`\\b${k}\\b`).test(lower))) return 0;
+  if (DIRECTOR_KEYWORDS.some((k) => new RegExp(`\\b${k}\\b`).test(lower))) return 1;
   return 2;
 }
 
@@ -123,7 +123,7 @@ export default function MeetTheTeam() {
       sorted[country] = [...membersByCountry[country]].sort(
         (a, b) => getMemberTier(a.memberPosition) - getMemberTier(b.memberPosition),
       );
-    }
+}
     return sorted;
   }, [membersByCountry]);
 

--- a/frontend/src/app/(public)/meet-the-team/page.tsx
+++ b/frontend/src/app/(public)/meet-the-team/page.tsx
@@ -123,7 +123,7 @@ export default function MeetTheTeam() {
       sorted[country] = [...membersByCountry[country]].sort(
         (a, b) => getMemberTier(a.memberPosition) - getMemberTier(b.memberPosition),
       );
-}
+    }
     return sorted;
   }, [membersByCountry]);
 

--- a/frontend/src/app/(public)/meet-the-team/page.tsx
+++ b/frontend/src/app/(public)/meet-the-team/page.tsx
@@ -128,8 +128,8 @@ export default function MeetTheTeam() {
   }, [membersByCountry]);
 
   const countries = Object.keys(membersByCountry).sort((a, b) => {
-    if (a === "United States") return -1;
-    if (b === "United States") return 1;
+    if (a === "United States of America") return -1;
+    if (b === "United States of America") return 1;
     return a.localeCompare(b);
   });
 

--- a/frontend/src/components/MemberCard.tsx
+++ b/frontend/src/components/MemberCard.tsx
@@ -15,18 +15,7 @@ type MemberCardProps = {
   member: Member;
 };
 
-const getLinkedInUsername = (url: string) => {
-  try {
-    const cleanUrl = url.endsWith("/") ? url.slice(0, -1) : url;
-    const parts = cleanUrl.split("/");
-    return parts[parts.length - 1];
-  } catch {
-    return "LinkedIn";
-  }
-};
-
 export const MemberCard: React.FC<MemberCardProps> = ({ member }) => {
-  const linkedInUsername = getLinkedInUsername(member.linkedinUrl);
   return (
     <>
       <div className="flex flex-col flex-start gap-[30px]">
@@ -87,9 +76,6 @@ export const MemberCard: React.FC<MemberCardProps> = ({ member }) => {
                 />
               </svg>
             </div>
-            <p className="font-dm-sans text-[16px] font-normal text-[#1E1E1E] leading-[24px] text-[#1E1E1E] group-hover:text-[#1169B0] transition-colors duration-300">
-              {linkedInUsername}
-            </p>
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Resolves #153 (remaining unchecked items 1–3).

- **US listed first**: The United States country section now always appears first below the "Our Team Around the World" heading, before all other countries sorted alphabetically.
- **Role-based member ordering**: Within each country section, members are now sorted by seniority — C-Suite executives and Co-Heads appear first, Directors second, and all other roles third. This applies globally across all country sections.
- **LinkedIn icon only**: The LinkedIn link on each member card now displays only the LinkedIn logo icon, removing the previously shown username text. The icon remains clickable and opens the member's LinkedIn profile in a new tab.

## Changes

- `frontend/src/app/(public)/meet-the-team/page.tsx`
  - Added `getMemberTier()` helper (outside component) to classify roles into 3 tiers: C-Suite/Co-Head (0), Director (1), Other (2)
  - Added `sortedMembersByCountry` memo that sorts members within each country by tier
  - Updated country sort to pin "United States" to the top
  - Pass `sortedMembersByCountry` instead of `membersByCountry` to `CountrySection`

- `frontend/src/components/MemberCard.tsx`
  - Removed `getLinkedInUsername()` helper (no longer needed)
  - Removed the username `<p>` element from the LinkedIn link, keeping only the SVG icon

## Test plan

- [ ] Visit `/meet-the-team` and verify the US section appears first
- [ ] Confirm C-Suite/Co-Head members appear before Directors, who appear before other roles within each country
- [ ] Confirm LinkedIn links show only the icon (no username text) and still navigate to the correct profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)