### PR TITLE
Extract Firebase Storage helpers into shared utility

### DIFF
--- a/frontend/src/app/(admin)/college-logos-editor/page.tsx
+++ b/frontend/src/app/(admin)/college-logos-editor/page.tsx
@@ -16,11 +16,11 @@ import {
   sortableKeyboardCoordinates,
 } from "@dnd-kit/sortable";
 import { onAuthStateChanged } from "firebase/auth";
-import type { StorageReference } from "firebase/storage";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import type { College } from "@/api/colleges";
+import type { StorageReference } from "firebase/storage";
 
 import { getAllColleges, updateColleges } from "@/api/colleges";
 import { AddCardDialog } from "@/components/admin-portal/AddCardDialog";

--- a/frontend/src/app/(admin)/college-logos-editor/page.tsx
+++ b/frontend/src/app/(admin)/college-logos-editor/page.tsx
@@ -16,13 +16,7 @@ import {
   sortableKeyboardCoordinates,
 } from "@dnd-kit/sortable";
 import { onAuthStateChanged } from "firebase/auth";
-import {
-  deleteObject,
-  getDownloadURL,
-  ref as storageRef,
-  type StorageReference,
-  uploadBytes,
-} from "firebase/storage";
+import type { StorageReference } from "firebase/storage";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
@@ -33,7 +27,8 @@ import { AddCardDialog } from "@/components/admin-portal/AddCardDialog";
 import { DraggableCollegeCard } from "@/components/admin-portal/DraggableSortableCard";
 import { HeaderSection } from "@/components/admin-portal/HeaderSection";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog";
-import { auth, storage } from "@/firebase/firebase";
+import { auth } from "@/firebase/firebase";
+import { deleteFromStorageUrl, rollbackUploads, uploadToStorage } from "@/utils/firebaseStorage";
 
 type CollegeItem = { id: string; _id?: string; name: string; imageUrl: string; file?: File };
 
@@ -98,11 +93,6 @@ export default function CollegeLogosEditorPage() {
     ]);
   }
 
-  const getStoragePathFromUrl = (url: string) => {
-    const match = /\/o\/(.*?)\?/.exec(url);
-    return match ? decodeURIComponent(match[1]) : null;
-  };
-
   function handleDelete(id: string) {
     setColleges((prev) => prev.filter((c) => c.id !== id));
   }
@@ -120,10 +110,11 @@ export default function CollegeLogosEditorPage() {
         colleges.map(async (college, index) => {
           let url = college.imageUrl;
           if (college.file) {
-            const firebaseRef = storageRef(storage, `colleges/${Date.now()}-${college.file.name}`);
-            const snapshot = await uploadBytes(firebaseRef, college.file);
-            url = await getDownloadURL(snapshot.ref);
-            newlyUploadedRefs.push(snapshot.ref);
+            url = await uploadToStorage(
+              college.file,
+              `colleges/${Date.now()}-${college.file.name}`,
+              newlyUploadedRefs,
+            );
           }
           return {
             _id: originalColleges.find((o) => o.name === college.name)?._id,
@@ -141,20 +132,12 @@ export default function CollegeLogosEditorPage() {
         .map((c) => originalColleges.find((o) => o.name === c.name)?.imageUrl)
         .filter(Boolean) as string[];
 
-      await Promise.all(
-        replacedUrls.map(async (url) => {
-          const path = getStoragePathFromUrl(url);
-          if (path) {
-            const fileRef = storageRef(storage, path);
-            await deleteObject(fileRef).catch(() => {});
-          }
-        }),
-      );
+      await Promise.all(replacedUrls.map(deleteFromStorageUrl));
 
       router.push("/admin-portal");
     } catch (error) {
       console.error("Critical Publish Error:", error);
-      await Promise.all(newlyUploadedRefs.map(async (ref) => deleteObject(ref).catch(() => {})));
+      await rollbackUploads(newlyUploadedRefs);
       setIsPublishing(false);
     }
   }

--- a/frontend/src/utils/firebaseStorage.ts
+++ b/frontend/src/utils/firebaseStorage.ts
@@ -1,0 +1,46 @@
+import { deleteObject, getDownloadURL, ref as storageRef, uploadBytes } from "firebase/storage";
+import type { StorageReference } from "firebase/storage";
+
+import { storage } from "@/firebase/firebase";
+
+/**
+ * Extracts the Firebase Storage object path from a Firebase Storage download URL.
+ * Returns null if the URL is not a valid Firebase Storage URL.
+ */
+export function getStoragePathFromUrl(url: string): string | null {
+  const match = /\/o\/(.*?)\?/.exec(url);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+/**
+ * Uploads a file to Firebase Storage at the given path and returns the public download URL.
+ * Optionally pushes the StorageReference onto `uploadedRefs` so the caller can roll back on error.
+ */
+export async function uploadToStorage(
+  file: File,
+  path: string,
+  uploadedRefs?: StorageReference[],
+): Promise<string> {
+  const fileRef = storageRef(storage, path);
+  const snapshot = await uploadBytes(fileRef, file);
+  const url = await getDownloadURL(snapshot.ref);
+  uploadedRefs?.push(snapshot.ref);
+  return url;
+}
+
+/**
+ * Deletes a file from Firebase Storage given its download URL.
+ * Silently ignores errors (e.g. file already deleted or URL not a storage URL).
+ */
+export async function deleteFromStorageUrl(url: string): Promise<void> {
+  const path = getStoragePathFromUrl(url);
+  if (!path) return;
+  await deleteObject(storageRef(storage, path)).catch(() => {});
+}
+
+/**
+ * Deletes all StorageReferences in the provided array. Used to roll back a failed publish.
+ */
+export async function rollbackUploads(refs: StorageReference[]): Promise<void> {
+  await Promise.all(refs.map((ref) => deleteObject(ref).catch(() => {})));
+}

--- a/frontend/src/utils/firebaseStorage.ts
+++ b/frontend/src/utils/firebaseStorage.ts
@@ -1,4 +1,5 @@
 import { deleteObject, getDownloadURL, ref as storageRef, uploadBytes } from "firebase/storage";
+
 import type { StorageReference } from "firebase/storage";
 
 import { storage } from "@/firebase/firebase";
@@ -42,5 +43,5 @@ export async function deleteFromStorageUrl(url: string): Promise<void> {
  * Deletes all StorageReferences in the provided array. Used to roll back a failed publish.
  */
 export async function rollbackUploads(refs: StorageReference[]): Promise<void> {
-  await Promise.all(refs.map((ref) => deleteObject(ref).catch(() => {})));
+  await Promise.all(refs.map(async (ref) => deleteObject(ref).catch(() => {})));
 }


### PR DESCRIPTION
## Summary

- Creates `frontend/src/utils/firebaseStorage.ts` with four reusable helpers for Firebase Storage image uploads
- Refactors `college-logos-editor` to use the new utility instead of inline logic

## Motivation

`college-logos-editor` had inline Firebase Storage upload, delete, and rollback logic. The admin portal has 5+ image-uploading editors planned (`team-members-editor`, `client-logos-editor`, `affiliation-logos-editor`, `client-highlights-editor`, `interactive-timeline-editor`) — without a shared utility, each would copy-paste the same pattern.

## New utility: `src/utils/firebaseStorage.ts`

| Export | Description |
|---|---|
| `uploadToStorage(file, path, uploadedRefs?)` | Upload a file to Firebase Storage, return the download URL. Optionally tracks the `StorageReference` for rollback. |
| `deleteFromStorageUrl(url)` | Delete a file given its Firebase Storage download URL. |
| `rollbackUploads(refs)` | Delete all refs collected during a failed publish — used in catch blocks. |
| `getStoragePathFromUrl(url)` | Extract the storage object path from a Firebase download URL. |

## Test plan

- [ ] Open the College Logos editor in the admin portal
- [ ] Replace an existing logo and publish — verify the new image appears and the old one is removed from Firebase Storage
- [ ] Add a new college logo and publish — verify it uploads correctly
- [ ] Trigger a publish failure (e.g. disconnect network mid-upload) and verify newly uploaded files are rolled back

🤖 Generated with [Claude Code](https://claude.com/claude-code)