### PR TITLE
fix: use contain instead of cover for highlight card images

### DIFF
--- a/frontend/src/components/HighlightCard.tsx
+++ b/frontend/src/components/HighlightCard.tsx
@@ -50,7 +50,7 @@ export function HighlightCard({
       aria-pressed={isActive}
     >
       <div
-        className={`relative w-full overflow-hidden ${
+        className={`relative w-full overflow-hidden bg-[#e8e8e8] ${
           isActive
             ? "h-[152px] md:h-[256px] rounded-t-[10px] md:rounded-t-[16px]"
             : "h-[114px] md:h-[176px] rounded-t-[7px] md:rounded-t-[11px]"
@@ -60,7 +60,7 @@ export function HighlightCard({
           src={highlight.imageUrl}
           alt={highlight.quoteText}
           fill
-          style={{ objectFit: "cover" }}
+          style={{ objectFit: "contain" }}
         />
         <div
           className={`pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(56,88,173,0)_52.539%,#172447_107.81%)]`}


### PR DESCRIPTION
Show full images in the client highlights carousel without cropping. Larger images were being cut off with object-fit: cover.

## Tracking Info

Resolves #<issue number>

## Changes

<!-- What changes did you make? -->

- TODO

## Testing

<!-- How did you confirm your changes worked? -->

- TODO

## Confirmation of Change

<!-- Upload a screenshot, if possible. Otherwise, please provide instructions on how to see the change. -->

TODO
